### PR TITLE
dpdk: Add header files for MUSL run-time

### DIFF
--- a/packages/dpdk/patches/900-vfio-pci-fix-musl-headers.patch
+++ b/packages/dpdk/patches/900-vfio-pci-fix-musl-headers.patch
@@ -1,0 +1,10 @@
+--- a/drivers/bus/pci/linux/pci_vfio.c
++++ b/drivers/bus/pci/linux/pci_vfio.c
+@@ -2,6 +2,7 @@
+  * Copyright(c) 2010-2014 Intel Corporation
+  */
+ 
++#include <unistd.h>
+ #include <string.h>
+ #include <fcntl.h>
+ #include <linux/pci_regs.h>


### PR DESCRIPTION
Should be fixed upstream but for now, allow progress building with MUSL